### PR TITLE
Handle double quote characters in text by escaping them.

### DIFF
--- a/Decompiler/age-shared.cpp
+++ b/Decompiler/age-shared.cpp
@@ -558,6 +558,16 @@ static consteval auto make_defs() {
 }
 static constexpr auto definitions = make_defs();
 
+std::string replace_string(std::string subject, const std::string& search,
+    const std::string& replace) {
+    size_t pos = 0;
+    while ((pos = subject.find(search, pos)) != std::string::npos) {
+        subject.replace(pos, search.length(), replace);
+        pos += replace.length();
+    }
+    return subject;
+}
+
 const Instruction_Definition* instruction_for_op_code(u32 op_code, std::streamoff offset) {
     size_t low = 0;
     size_t high = definitions.size() - 1;

--- a/Decompiler/age-shared.h
+++ b/Decompiler/age-shared.h
@@ -155,6 +155,7 @@ struct Instruction {
     }
 };
 
+std::string replace_string(std::string subject, const std::string& search, const std::string& replace);
 const Instruction_Definition* instruction_for_op_code(u32 op_code, std::streamoff offset);
 const Instruction_Definition* instruction_for_label(const std::string_view label);
 

--- a/Decompiler/disassembler.cpp
+++ b/Decompiler/disassembler.cpp
@@ -41,8 +41,10 @@ Instruction parse_instruction(std::istream& fd, Header& header, const Instructio
                 }
 
                 // convert it over to UTF8 for easier text editing
-                arg.decoded_stringv4 = utf16_to_cp(CP_UTF8, utf16_decoded);
-            } else {
+                auto pre_replace_string = utf16_to_cp(CP_UTF8, utf16_decoded);
+                arg.decoded_stringv4 = replace_string(pre_replace_string, "\"", "\\u0022");
+            } 
+            else {
                 // SJIS -> UTF8
                 u8 character{};
                 fd.read((char*)&character, sizeof(character));
@@ -53,7 +55,8 @@ Instruction parse_instruction(std::istream& fd, Header& header, const Instructio
                 }
 
                 // convert it over to UTF8 for easier text editing
-                arg.decoded_stringv4 = utf16_to_cp(CP_UTF8, cp_to_utf16(CP_932, decoded));
+                auto pre_replace_string = utf16_to_cp(CP_UTF8, cp_to_utf16(CP_932, decoded));
+                arg.decoded_stringv4 = replace_string(pre_replace_string, "\"", "\\u0022");
             }
 
             // Go back to the instruction position

--- a/Decompiler/reassembler.cpp
+++ b/Decompiler/reassembler.cpp
@@ -236,12 +236,13 @@ std::stringstream assemble(std::istream& fd) {
                     // We'll have to "restore" this argument's data later on as the offset where the string will be written
                     current.type = 2;
 
+                    auto replaced_string = replace_string(arg[ARGUMENT_TYPE::STR], "\\u0022", "\"");
                     if (header.IsVer5()) {
                         // Convert back to UTF16
-                        current.decoded_stringv5 = cp_to_utf16(CP_UTF8, arg[ARGUMENT_TYPE::STR]);
+                        current.decoded_stringv5 = cp_to_utf16(CP_UTF8, replaced_string);
                     } else {
                         // Convert back to CP932
-                        current.decoded_stringv4 = utf16_to_cp(CP_932, cp_to_utf16(CP_UTF8, arg[ARGUMENT_TYPE::STR]));
+                        current.decoded_stringv4 = utf16_to_cp(CP_932, cp_to_utf16(CP_UTF8, replaced_string));
                     }
 
                     string_arguments.push_back(current_index);


### PR DESCRIPTION
Prior to this PR, the program can decompile text which contains quotes `"`, but it is not able to recompile them as they get caught by regex to parse arguments.

This PR makes it so that any quotes get decompiled as `\u0022` (the unicode codepoint for `"`) and compiles the same string as `"`.

Briefly tested on Hyakusen.